### PR TITLE
Set pin for aiobotocore

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - poetry-dynamic-versioning
   run:
     - python >=3.8
-    - aiobotocore ==2.7.0
+    - aiobotocore >=2.7.0,<=2.12.3
     - boto3 >=1.21.21
     - cryptography >=37.0.0
     - idna >=3.3.0


### PR DESCRIPTION
Update allowed pins for 12.4.0, see https://github.com/terricain/aioboto3/commit/54ebba5029a24362c2c634136e8cfae0ee0e3254 as latest state